### PR TITLE
Add CRUD Operations and Entity Linking for Bands and Festivals with Service and Repository Refactoring

### DIFF
--- a/ShowTime/Components/Layout/NavMenu.razor
+++ b/ShowTime/Components/Layout/NavMenu.razor
@@ -25,6 +25,19 @@
                 <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Weather
             </NavLink>
         </div>
+
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="BandCrudTest">
+                <span class="bi bi-music-note-beamed-nav-menu" aria-hidden="true"></span> Band CRUD Test
+            </NavLink>
+		</div>
+
+		<div class="nav-item px-3">
+			<NavLink class="nav-link" href="FestivalCrudTest">
+				<span class="bi bi-calendar-event-nav-menu" aria-hidden="true"></span> Festival CRUD Test
+			</NavLink>
+		</div>
+
     </nav>
 </div>
 

--- a/ShowTime/Components/Pages/BandCrudTest.razor
+++ b/ShowTime/Components/Pages/BandCrudTest.razor
@@ -1,6 +1,6 @@
 @page "/BandCrudTest"
 @rendermode InteractiveServer
-@inject IService<Band> BandService
+@inject IBandService BandService
 
 <h3>Band CRUD Test</h3>
 

--- a/ShowTime/Components/Pages/BandCrudTest.razor
+++ b/ShowTime/Components/Pages/BandCrudTest.razor
@@ -15,6 +15,22 @@ else
 		@foreach (var band in Bands)
 		{
 			<li>Id: @band.Id Name: @band.Name - (@band.Genre)</li>
+			@if (band.Festivals != null && band.Festivals.Any())
+			{
+				<li>
+					Festivals:
+					<ul>
+						@foreach (var festival in band.Festivals)
+						{
+							<li>@festival.Name</li>
+						}
+					</ul>
+				</li>
+			}
+			else
+			{
+				<li>No festivals linked to this band.</li>
+			}
 		}
 	</ul>
 }
@@ -50,73 +66,4 @@ else
 <input @bind="DeleteBandId" placeholder="Band ID" type="number" />
 <Button Color="Color.Danger" @onclick="DeleteBand">Delete</Button>
 
-@code {
-	private List<Band>? Bands;
-	private string NewBandName = string.Empty;
-	private Genre NewBandGenre;
-	private int UpdateBandId;
-	private string UpdateBandName = string.Empty;
-	private Genre UpdateBandGenre;
-	private int DeleteBandId;
 
-	protected override async Task OnInitializedAsync()
-	{
-		await LoadBands();
-	}
-
-	private async Task LoadBands()
-	{
-		try
-		{
-			Bands = (await BandService.GetAllAsync()).ToList();
-		}
-		catch (Exception ex)
-		{
-			Console.WriteLine($"Error loading bands: {ex.Message}");
-		}
-	}
-
-	private async Task AddBand()
-	{
-		var newBand = new Band
-			{
-				Name = NewBandName,
-				Genre = NewBandGenre
-			};
-
-		await BandService.AddAsync(newBand);
-		await LoadBands();
-
-		NewBandName = string.Empty;
-		NewBandGenre = Genre.Rock;
-	}
-
-	private async Task UpdateBand()
-	{
-		var bandToUpdate = await BandService.GetByIdAsync(UpdateBandId);
-		if (bandToUpdate != null)
-		{
-			bandToUpdate.Name = UpdateBandName;
-			bandToUpdate.Genre = UpdateBandGenre;
-
-			await BandService.UpdateAsync(bandToUpdate);
-			await LoadBands();
-
-			UpdateBandId = 0;
-			UpdateBandName = string.Empty;
-			UpdateBandGenre = Genre.Rock;
-		}
-	}
-
-	private async Task DeleteBand()
-	{
-		var bandToDelete = await BandService.GetByIdAsync(DeleteBandId);
-		if (bandToDelete != null)
-		{
-			await BandService.DeleteAsync(bandToDelete);
-			await LoadBands();
-
-			DeleteBandId = 0;
-		}
-	}
-}

--- a/ShowTime/Components/Pages/BandCrudTest.razor.cs
+++ b/ShowTime/Components/Pages/BandCrudTest.razor.cs
@@ -27,7 +27,7 @@ namespace ShowTime.Components.Pages
         {
             try
             {
-                Bands = (await BandService.GetAllAsync()).ToList();
+                Bands = (await BandService.GetBandsWithFestivalsAsync()).ToList();
             }
             catch (Exception ex)
             {

--- a/ShowTime/Components/Pages/BandCrudTest.razor.cs
+++ b/ShowTime/Components/Pages/BandCrudTest.razor.cs
@@ -1,0 +1,83 @@
+using ShowTime.Entities;
+using ShowTime.Enum;
+
+
+namespace ShowTime.Components.Pages
+{
+    public partial class BandCrudTest
+    {
+        private List<Band>? Bands;
+        private List<Festival>? Festivals;
+
+        private string NewBandName = string.Empty;
+        private Genre NewBandGenre;
+
+        private int UpdateBandId;
+        private string UpdateBandName = string.Empty;
+        private Genre UpdateBandGenre;
+
+        private int DeleteBandId;
+
+        protected override async Task OnInitializedAsync()
+        {
+            await LoadBands();
+        }
+
+        private async Task LoadBands()
+        {
+            try
+            {
+                Bands = (await BandService.GetAllAsync()).ToList();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error loading bands: {ex.Message}");
+            }
+        }
+
+        private async Task AddBand()
+        {
+            var newBand = new Band
+            {
+                Name = NewBandName,
+                Genre = NewBandGenre
+            };
+
+            await BandService.AddAsync(newBand);
+            await LoadBands();
+
+            NewBandName = string.Empty;
+            NewBandGenre = Genre.Rock;
+        }
+
+        private async Task UpdateBand()
+        {
+            var bandToUpdate = await BandService.GetByIdAsync(UpdateBandId);
+            if (bandToUpdate != null)
+            {
+                bandToUpdate.Name = UpdateBandName;
+                bandToUpdate.Genre = UpdateBandGenre;
+
+                await BandService.UpdateAsync(bandToUpdate);
+                await LoadBands();
+
+                UpdateBandId = 0;
+                UpdateBandName = string.Empty;
+                UpdateBandGenre = Genre.Rock;
+            }
+
+        }
+
+        private async Task DeleteBand()
+        {
+            var bandToDelete = await BandService.GetByIdAsync(DeleteBandId);
+            if (bandToDelete != null)
+            {
+                await BandService.DeleteAsync(bandToDelete);
+                await LoadBands();
+
+                DeleteBandId = 0;
+            }
+        }
+    }
+}

--- a/ShowTime/Components/Pages/FestivalCrudTest.razor
+++ b/ShowTime/Components/Pages/FestivalCrudTest.razor
@@ -1,0 +1,104 @@
+﻿@page "/FestivalCrudTest"  
+@rendermode InteractiveServer  
+@inject IService<Band> BandService  
+@inject IFestivalService FestivalService
+
+<h3>Festival CRUD Test</h3>  
+
+<!-- Add Festival Section -->  
+<h4>Add Festival</h4>  
+<div>  
+   <label>Name:</label>  
+   <input @bind="NewFestivalName" />  
+</div>  
+<div>  
+   <label>Location:</label>  
+   <input @bind="NewFestivalLocation" />  
+</div>  
+<div>  
+   <label>Start Date:</label>  
+   <input type="date" @bind="NewFestivalStartDate" />  
+</div>  
+<div>  
+   <label>End Date:</label>  
+   <input type="date" @bind="NewFestivalEndDate" />  
+</div>  
+<button @onclick="AddFestival">Add Festival</button>  
+
+<!--Link Band to Festival Section-->
+<h4>Link Band to Festival</h4>
+
+<div>
+   <label>Festival ID:</label>
+    <input type="number" @bind="SelectedFestivalId" />
+</div>
+<div>
+   <label>Band ID:</label>
+   <input type="number" @bind="SelectedBandId" />
+</div>
+<button @onclick="AddBandToFestival">Link Band to Festival</button>
+
+
+<!-- Update Festival Section -->  
+<h4>Update Festival</h4>  
+<div>  
+   <label>Festival ID:</label>  
+   <input type="number" @bind="UpdateFestivalId" />  
+</div>  
+<div>  
+   <label>Name:</label>  
+   <input @bind="UpdateFestivalName" />  
+</div>  
+<div>  
+   <label>Location:</label>  
+   <input @bind="UpdateFestivalLocation" />  
+</div>  
+<div>  
+   <label>Start Date:</label>  
+   <input type="date" @bind="UpdateFestivalStartDate" />  
+</div>  
+<div>  
+   <label>End Date:</label>  
+   <input type="date" @bind="UpdateFestivalEndDate" />  
+</div>  
+<button @onclick="UpdateFestival">Update Festival</button>  
+
+<!-- Delete Festival Section -->  
+<h4>Delete Festival</h4>  
+<div>  
+   <label>Festival ID:</label>  
+   <input type="number" @bind="DeleteFestivalId" />  
+</div>  
+<button @onclick="DeleteFestival">Delete Festival</button>  
+
+<!-- List Festivals Section -->  
+<h4>Festivals</h4>  
+@if (Festivals != null && Festivals.Any())  
+{  
+   <ul>  
+       @foreach (var festival in Festivals)  
+       {  
+           <li>Id: @festival.Id  @festival.Name (@festival.Location) - @festival.StartDate.ToShortDateString() to @festival.EndDate.ToShortDateString()</li>
+            @if (festival.Bands != null && festival.Bands.Any())
+            {
+                <li>
+                    Bands:
+                    <ul>
+                        @foreach (var band in festival.Bands)
+                        {
+                            <li>@band.Name</li>
+                        }
+                    </ul>
+                </li>
+            }
+            else
+            {
+                <li>No bands linked to this festival.</li>
+            }
+       }  
+   </ul>  
+}  
+else  
+{  
+   <p>No festivals available.</p>  
+}

--- a/ShowTime/Components/Pages/FestivalCrudTest.razor
+++ b/ShowTime/Components/Pages/FestivalCrudTest.razor
@@ -1,6 +1,6 @@
 ﻿@page "/FestivalCrudTest"  
 @rendermode InteractiveServer  
-@inject IService<Band> BandService  
+@inject IBandService BandService  
 @inject IFestivalService FestivalService
 
 <h3>Festival CRUD Test</h3>  

--- a/ShowTime/Components/Pages/FestivalCrudTest.razor.cs
+++ b/ShowTime/Components/Pages/FestivalCrudTest.razor.cs
@@ -1,0 +1,109 @@
+using ShowTime.Entities;
+
+namespace ShowTime.Components.Pages
+{
+    public partial class FestivalCrudTest
+    {
+        private List<Festival>? Festivals;
+        private List<Band>? Bands;
+
+        private string NewFestivalName = string.Empty;
+        private string NewFestivalLocation = string.Empty;
+        private DateTime NewFestivalStartDate = DateTime.Now;
+        private DateTime NewFestivalEndDate = DateTime.Now.AddDays(1);
+
+        // For adding a band to a festival, we need to select the festival and the band.
+        private int SelectedFestivalId;
+        private int SelectedBandId;
+
+        private int UpdateFestivalId;
+        private string UpdateFestivalName = string.Empty;
+        private string UpdateFestivalLocation = string.Empty;
+        private DateTime UpdateFestivalStartDate = DateTime.Now;
+        private DateTime UpdateFestivalEndDate = DateTime.Now.AddDays(1);
+
+        private int DeleteFestivalId;
+
+        protected override async Task OnInitializedAsync()
+        {
+            await LoadFestivals();
+        }
+
+        private async Task LoadFestivals()
+        {
+            try
+            {
+                Festivals = (await FestivalService.GetFestivalsWithBandsAsync()).ToList();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error loading festivals: {ex.Message}");
+            }
+        }
+
+        private async Task AddFestival()
+        {
+            var newFestival = new Festival
+            {
+                Name = NewFestivalName,
+                Location = NewFestivalLocation,
+                StartDate = NewFestivalStartDate,
+                EndDate = NewFestivalEndDate
+            };
+            await FestivalService.AddAsync(newFestival);
+            await LoadFestivals();
+
+            NewFestivalName = string.Empty;
+            NewFestivalLocation = string.Empty;
+            NewFestivalStartDate = DateTime.Now;
+            NewFestivalEndDate = DateTime.Now.AddDays(1);
+        }
+
+        private async Task AddBandToFestival()
+        {
+            try
+            {
+                await FestivalService.AddBandtoFestival(SelectedBandId, SelectedFestivalId);
+                await LoadFestivals();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error adding band to festival: {ex.Message}");
+            }
+        }
+
+        private async Task UpdateFestival()
+        {
+            var festivalToUpdate = await FestivalService.GetByIdAsync(UpdateFestivalId);
+            if (festivalToUpdate != null)
+            {
+                festivalToUpdate.Name = UpdateFestivalName;
+                festivalToUpdate.Location = UpdateFestivalLocation;
+                festivalToUpdate.StartDate = UpdateFestivalStartDate;
+                festivalToUpdate.EndDate = UpdateFestivalEndDate;
+
+                await FestivalService.UpdateAsync(festivalToUpdate);
+                await LoadFestivals();
+
+                UpdateFestivalId = 0;
+                UpdateFestivalName = string.Empty;
+                UpdateFestivalLocation = string.Empty;
+                UpdateFestivalStartDate = DateTime.Now;
+                UpdateFestivalEndDate = DateTime.Now.AddDays(1);
+            }
+        }
+
+        private async Task DeleteFestival()
+        {
+            var festivalToDelete = await FestivalService.GetByIdAsync(DeleteFestivalId);
+
+            if (festivalToDelete != null)
+            {
+                await FestivalService.DeleteAsync(festivalToDelete);
+                await LoadFestivals();
+
+                DeleteFestivalId = 0;
+            }
+        }
+    }
+}

--- a/ShowTime/Context/ShowTimeDbContext.cs
+++ b/ShowTime/Context/ShowTimeDbContext.cs
@@ -11,6 +11,5 @@ namespace ShowTime.Context
         public DbSet<Band> Bands { get; set; } = null!;
         public DbSet<Booking> Bookings { get; set; } = null!;
         public DbSet<Festival> Festivals { get; set; } = null!;
-
     }
 }

--- a/ShowTime/Program.cs
+++ b/ShowTime/Program.cs
@@ -20,10 +20,17 @@ builder.Services.AddDbContext<ShowTimeDbContext>(options =>
     options.UseSqlServer(connectionString));
 
 // Register services and repositories
+// Generic
 builder.Services.AddScoped(typeof(IRepository<>), typeof(Repository<>));
 builder.Services.AddScoped(typeof(IService<>), typeof(Service<>));
+
+//Festival
 builder.Services.AddScoped<IFestivalRepository, FestivalRepository>();
 builder.Services.AddScoped<IFestivalService, FestivalService>();
+
+//Band
+builder.Services.AddScoped<IBandRepository, BandRepository>();
+builder.Services.AddScoped<IBandService, BandSerivce>();
 
 // Add services to the container.
 builder.Services.AddRazorComponents()

--- a/ShowTime/Program.cs
+++ b/ShowTime/Program.cs
@@ -22,6 +22,8 @@ builder.Services.AddDbContext<ShowTimeDbContext>(options =>
 // Register services and repositories
 builder.Services.AddScoped(typeof(IRepository<>), typeof(Repository<>));
 builder.Services.AddScoped(typeof(IService<>), typeof(Service<>));
+builder.Services.AddScoped<IFestivalRepository, FestivalRepository>();
+builder.Services.AddScoped<IFestivalService, FestivalService>();
 
 // Add services to the container.
 builder.Services.AddRazorComponents()

--- a/ShowTime/Repositories/Implementations/BandRepository.cs
+++ b/ShowTime/Repositories/Implementations/BandRepository.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.EntityFrameworkCore;
+using ShowTime.Context;
+using ShowTime.Entities;
+using ShowTime.Repositories.Interfaces;
+
+namespace ShowTime.Repositories.Implementations
+{
+    public class BandRepository : Repository<Band>, IBandRepository
+    {
+        private readonly ShowTimeDbContext _context;
+        private readonly DbSet<Band> _dbSet;
+
+        public BandRepository(ShowTimeDbContext context) : base(context) 
+        {
+            _context = context;
+            _dbSet = context.Bands;
+        }
+
+        public async Task<IEnumerable<Band>> GetBandsWithFestivalsAsync()
+        {
+            return await _dbSet.Include(b => b.Festivals).ToListAsync();
+        }
+    }
+}

--- a/ShowTime/Repositories/Implementations/FestivalRepository.cs
+++ b/ShowTime/Repositories/Implementations/FestivalRepository.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.EntityFrameworkCore;
+using ShowTime.Context;
+using ShowTime.Entities;
+using ShowTime.Repositories.Interfaces;
+
+namespace ShowTime.Repositories.Implementations
+{
+    public class FestivalRepository : Repository<Festival>, IFestivalRepository
+    {
+        private readonly ShowTimeDbContext _context;
+        private readonly DbSet<Festival> _dbSet;
+
+        public FestivalRepository(ShowTimeDbContext context) : base(context)
+        {
+            _context = context;
+            _dbSet = context.Festivals;
+        }
+
+        public async Task<IEnumerable<Festival>> GetFestivalsWithBandsAsync()
+        {
+            return await _dbSet.Include(f => f.Bands).ToListAsync();
+        }
+    }
+}

--- a/ShowTime/Repositories/Interfaces/IBandRepository.cs
+++ b/ShowTime/Repositories/Interfaces/IBandRepository.cs
@@ -1,0 +1,8 @@
+﻿using ShowTime.Entities;
+
+namespace ShowTime.Repositories.Interfaces
+{
+    public interface IBandRepository : IRepository<Band>
+    {
+    }
+}

--- a/ShowTime/Repositories/Interfaces/IFestivalRepository.cs
+++ b/ShowTime/Repositories/Interfaces/IFestivalRepository.cs
@@ -1,0 +1,10 @@
+﻿using ShowTime.Entities;
+
+namespace ShowTime.Repositories.Interfaces
+{
+    public interface IFestivalRepository : IRepository<Festival>
+    {
+        Task<IEnumerable<Festival>> GetFestivalsWithBandsAsync();
+
+    }
+}

--- a/ShowTime/Repositories/Interfaces/IFestivalRepository.cs
+++ b/ShowTime/Repositories/Interfaces/IFestivalRepository.cs
@@ -5,6 +5,5 @@ namespace ShowTime.Repositories.Interfaces
     public interface IFestivalRepository : IRepository<Festival>
     {
         Task<IEnumerable<Festival>> GetFestivalsWithBandsAsync();
-
     }
 }

--- a/ShowTime/Services/Implementations/BandSerivce.cs
+++ b/ShowTime/Services/Implementations/BandSerivce.cs
@@ -1,0 +1,17 @@
+﻿using ShowTime.Entities;
+using ShowTime.Repositories.Interfaces;
+using ShowTime.Services.Interfaces;
+
+namespace ShowTime.Services.Implementations
+{
+    public class BandSerivce(IBandRepository bandRepository, IFestivalRepository festivalRepository) : Service<Band>(bandRepository), IBandService
+    {
+        private readonly IBandRepository _bandRepository = bandRepository;
+        private readonly IFestivalRepository _estivalRepository = festivalRepository;
+
+        public async Task<IEnumerable<Band>> GetBandsWithFestivalsAsync()
+        {
+            return await _bandRepository.GetBandsWithFestivalsAsync();
+        }
+    }
+}

--- a/ShowTime/Services/Implementations/FestivalService.cs
+++ b/ShowTime/Services/Implementations/FestivalService.cs
@@ -1,0 +1,34 @@
+﻿using ShowTime.Entities;
+using ShowTime.Repositories.Interfaces;
+using ShowTime.Services.Interfaces;
+
+namespace ShowTime.Services.Implementations
+{
+    public class FestivalService(IFestivalRepository festivalRepository, IRepository<Band> bandRepository) : Service<Festival>(festivalRepository), IFestivalService
+    {
+        private readonly IFestivalRepository _festivalRepository = festivalRepository;
+        private readonly IRepository<Band> _bandRepository = bandRepository;
+        public async Task<IEnumerable<Festival>> GetFestivalsWithBandsAsync()
+        {
+            return await _festivalRepository.GetFestivalsWithBandsAsync();
+        }
+
+        public async Task AddBandtoFestival(int bandId, int festivalId)
+        {
+            var festival = await _festivalRepository.GetByIdAsync(festivalId)
+                ?? throw new ArgumentException($"Festival with ID {festivalId} not found.");
+
+            var band = await _bandRepository.GetByIdAsync(bandId)
+                ?? throw new ArgumentException($"Band with ID {bandId} not found.");
+
+            if (festival.Bands.Any(b => b.Id == bandId))
+            {
+                throw new InvalidOperationException($"Band with ID {bandId} is already added to the festival with ID {festivalId}.");
+            }
+
+            festival.Bands.Add(band);
+            await _festivalRepository.UpdateAsync(festival);
+            await _festivalRepository.SaveChangesAsync();
+        }
+    }
+}

--- a/ShowTime/Services/Implementations/FestivalService.cs
+++ b/ShowTime/Services/Implementations/FestivalService.cs
@@ -4,7 +4,7 @@ using ShowTime.Services.Interfaces;
 
 namespace ShowTime.Services.Implementations
 {
-    public class FestivalService(IFestivalRepository festivalRepository, IRepository<Band> bandRepository) : Service<Festival>(festivalRepository), IFestivalService
+    public class FestivalService(IFestivalRepository festivalRepository, IBandRepository bandRepository) : Service<Festival>(festivalRepository), IFestivalService
     {
         private readonly IFestivalRepository _festivalRepository = festivalRepository;
         private readonly IRepository<Band> _bandRepository = bandRepository;

--- a/ShowTime/Services/Interfaces/IBandService.cs
+++ b/ShowTime/Services/Interfaces/IBandService.cs
@@ -1,8 +1,8 @@
 ﻿using ShowTime.Entities;
 
-namespace ShowTime.Repositories.Interfaces
+namespace ShowTime.Services.Interfaces
 {
-    public interface IBandRepository : IRepository<Band>
+    public interface IBandService : IService<Band>
     {
         Task<IEnumerable<Band>> GetBandsWithFestivalsAsync();
     }

--- a/ShowTime/Services/Interfaces/IFestivalService.cs
+++ b/ShowTime/Services/Interfaces/IFestivalService.cs
@@ -1,0 +1,10 @@
+﻿using ShowTime.Entities;
+
+namespace ShowTime.Services.Interfaces
+{
+    public interface IFestivalService : IService<Festival>
+    {
+        Task<IEnumerable<Festival>> GetFestivalsWithBandsAsync();
+        Task AddBandtoFestival(int bandId, int festivalId);
+    }
+}


### PR DESCRIPTION
#### PR Classification  
New feature: Added CRUD functionality and entity linking for bands and festivals.  

#### PR Summary  
Introduced pages and backend logic for managing bands and festivals, including linking entities and refactoring code for maintainability.  
- **`BandCrudTest.razor` and `FestivalCrudTest.razor`**: Added CRUD operations and UI for managing bands and festivals with linked entities.  
- **`BandRepository.cs` and `FestivalRepository.cs`**: Implemented repository methods for fetching entities with relationships.  
- **`BandService.cs` and `FestivalService.cs`**: Added service logic for CRUD operations and linking entities.  
- **`ShowTimeDbContext.cs`**: Added `DbSet` properties for `Band` and `Festival` entities.  
- **`Program.cs`**: Registered repositories and services for bands and festivals.  
