### PR TITLE
Refactor Band-Festival relationship with BandFestival entity

### DIFF
--- a/ShowTime/Components/Pages/BandCrudTest.razor
+++ b/ShowTime/Components/Pages/BandCrudTest.razor
@@ -54,14 +54,14 @@
 											<p class="card-text mb-2">
 												<span class="badge bg-info">@band.Genre</span>
 											</p>
-											@if (band.Festivals != null && band.Festivals.Any())
+											@if (band.BandFestivals != null && band.BandFestivals.Any())
 											{
 												<div>
 													<small class="text-muted fw-bold">Festivals:</small>
 													<div class="mt-1">
-														@foreach (var festival in band.Festivals)
+														@foreach (var festival in band.BandFestivals)
 														{
-															<span class="badge bg-light text-dark me-1 mb-1">@festival.Name</span>
+															<span class="badge bg-light text-dark me-1 mb-1">@festival.Festival.Name</span>
 														}
 													</div>
 												</div>

--- a/ShowTime/Components/Pages/BandCrudTest.razor.cs
+++ b/ShowTime/Components/Pages/BandCrudTest.razor.cs
@@ -26,7 +26,8 @@ namespace ShowTime.Components.Pages
         { 
             try
             {
-                Bands = (await BandService.GetAllIncludingAsync(b => b.Festivals)).ToList();
+                Bands = (await BandService.GetAllIncludingAsync(b => b.BandFestivals,
+                                                                b => (b.BandFestivals as BandFestival).Festival)).ToList();
             }
             catch (Exception ex)
             {

--- a/ShowTime/Components/Pages/Bands/BandList.razor
+++ b/ShowTime/Components/Pages/Bands/BandList.razor
@@ -75,7 +75,7 @@
 
                             <!-- Content Section - Flexible height -->
                             <Div Class="flex-grow-1" Style="min-height: 80px; max-height: 100px; overflow: hidden;">
-                                @if (band.Festivals != null && band.Festivals.Any())
+                                @if (band.BandFestivals != null && band.BandFestivals.Any())
                                 {
                                     <Div Margin="Margin.Is2.FromBottom">
                                         <Small TextColor="TextColor.Muted" TextWeight="TextWeight.Bold">
@@ -83,16 +83,16 @@
                                             Upcoming Festivals:
                                         </Small>
                                         <Div Margin="Margin.Is2.FromTop" Style="max-height: 60px; overflow: hidden;">
-                                            @foreach (var festival in band.Festivals.Take(3))
+                                            @foreach (var festival in band.BandFestivals.Take(3))
                                             {
                                                 <Badge Color="Color.Light" TextColor="TextColor.Dark" Margin="Margin.Is1.FromEnd.Is1.FromBottom">
-                                                    @festival.Name
+													@festival.Festival.Name
                                                 </Badge>
                                             }
-                                            @if (band.Festivals.Count > 3)
+                                            @if (band.BandFestivals.Count > 3)
                                             {
                                                 <Badge Color="Color.Secondary" TextColor="TextColor.White">
-                                                    +@(band.Festivals.Count - 3) more
+                                                    +@(band.BandFestivals.Count - 3) more
                                                 </Badge>
                                             }
                                         </Div>
@@ -134,7 +134,7 @@
                     <AlertMessage>
                         <Icon Name="IconName.InfoCircle" Margin="Margin.Is2.FromEnd" />
                         <Strong>Directory Summary:</Strong>
-                        Showing @Bands.Count band@(Bands.Count != 1 ? "s" : "") with @Bands.Sum(b => b.Festivals?.Count ?? 0) total festival booking@(Bands.Sum(b => b.Festivals?.Count ?? 0) != 1 ? "s" : "")
+                        Showing @Bands.Count band@(Bands.Count != 1 ? "s" : "") with @Bands.Sum(b => b.BandFestivals?.Count ?? 0) total festival booking@(Bands.Sum(b => b.BandFestivals?.Count ?? 0) != 1 ? "s" : "")
                     </AlertMessage>
                 </Alert>
             </Column>

--- a/ShowTime/Components/Pages/Bands/BandList.razor.cs
+++ b/ShowTime/Components/Pages/Bands/BandList.razor.cs
@@ -16,7 +16,8 @@ namespace ShowTime.Components.Pages.Bands
         {
             try
             {
-                Bands = (await BandService.GetAllIncludingAsync(b => b.Festivals)).ToList();
+                Bands = (await BandService.GetAllIncludingAsync(b => b.BandFestivals,
+                                                                b => (b.BandFestivals as BandFestival).Festival)).ToList();
             }
             catch (Exception ex)
             {

--- a/ShowTime/Components/Pages/FestivalCrudTest.razor
+++ b/ShowTime/Components/Pages/FestivalCrudTest.razor
@@ -45,14 +45,14 @@
 													@festival.StartDate.ToShortDateString() - @festival.EndDate.ToShortDateString()
 												</small>
 											</p>
-											@if (festival.Bands != null && festival.Bands.Any())
+											@if (festival.BandFestivals != null && festival.BandFestivals.Any())
 											{
 												<div>
 													<small class="text-muted fw-bold">Performing Bands:</small>
 													<div class="mt-1">
-														@foreach (var band in festival.Bands)
+														@foreach (var band in festival.BandFestivals)
 														{
-															<span class="badge bg-light text-dark me-1 mb-1">@band.Name</span>
+															<span class="badge bg-light text-dark me-1 mb-1">@band.Band.Name</span>
 														}
 													</div>
 												</div>

--- a/ShowTime/Components/Pages/FestivalCrudTest.razor.cs
+++ b/ShowTime/Components/Pages/FestivalCrudTest.razor.cs
@@ -32,7 +32,8 @@ namespace ShowTime.Components.Pages
         {
             try
             {
-                Festivals = (await FestivalService.GetAllIncludingAsync(f => f.Bands)).ToList();
+                Festivals = (await FestivalService.GetAllIncludingAsync(f => f.BandFestivals,
+                                                                        f => (f.BandFestivals as BandFestival).Band)).ToList();
             }
             catch (Exception ex)
             {

--- a/ShowTime/Components/Pages/Festivals/CreateFestival.razor.cs
+++ b/ShowTime/Components/Pages/Festivals/CreateFestival.razor.cs
@@ -36,7 +36,14 @@ namespace ShowTime.Components.Pages.Festivals
         }
         private async Task AddFestival()
         {
-            var selectedBands = AllBands?.Where(b => SelectedBandIds.Contains(b.Id)).ToList() ?? new List<Band>();
+            var selectedBands = AllBands?.Where(b => SelectedBandIds.Contains(b.Id))
+              .Select(b => new BandFestival
+              {
+                  BandsId = b.Id,
+                  Band = b,
+              }).ToList() ?? new List<BandFestival>();
+
+
 
             var newFestival = new Festival
             {
@@ -45,7 +52,7 @@ namespace ShowTime.Components.Pages.Festivals
                 Location = NewFestivalLocation,
                 StartDate = NewFestivalStartDate,
                 EndDate = NewFestivalEndDate,
-                Bands = selectedBands,
+                BandFestivals = selectedBands,
                 Photo = NewFestivalPhoto
             };
 

--- a/ShowTime/Components/Pages/Festivals/FestivalDetails.razor
+++ b/ShowTime/Components/Pages/Festivals/FestivalDetails.razor
@@ -102,7 +102,7 @@
 							<div class="stat-item">
 								<i class="fas fa-users stat-icon"></i>
 								<div class="stat-content">
-									<h3>@(Festival.Bands?.Count ?? 0)</h3>
+									<h3>@(Festival.BandFestivals?.Count ?? 0)</h3>
 									<p>Bands</p>
 								</div>
 							</div>
@@ -135,24 +135,24 @@
 					<div class="section-header">
 						<h2>
 							<i class="fas fa-music me-3"></i>
-							Performing Bands (@(Festival.Bands?.Count ?? 0))
+							Performing Bands (@(Festival.BandFestivals?.Count ?? 0))
 						</h2>
 					</div>
 
-					@if (Festival.Bands != null && Festival.Bands.Any())
+					@if (Festival.BandFestivals != null && Festival.BandFestivals.Any())
 					{
 						<div class="bands-grid">
-							@foreach (var band in Festival.Bands)
+							@foreach (var band in Festival.BandFestivals)
 							{
-								<div class="band-card" @onclick="() => NavigateToBandDetails(band.Id)">
+								<div class="band-card" @onclick="() => NavigateToBandDetails(band.BandsId)">
 									<div class="band-image">
-										<img src="@(band.Photo != null ? $"data:image/jpeg;base64,{Convert.ToBase64String(band.Photo)}" : "https://img.freepik.com/free-vector/cerulean-blue-curve-frame-template-vector_53876-136094.jpg")"
-											 alt="@($"{band.Name} photo")" />
+										<img src="@(band.Band.Photo != null ? $"data:image/jpeg;base64,{Convert.ToBase64String(band.Band.Photo)}" : "https://img.freepik.com/free-vector/cerulean-blue-curve-frame-template-vector_53876-136094.jpg")"
+											 alt="@($"{band.Band.Name} photo")" />
 									</div>
 									<div class="band-info">
-										<h5>@band.Name</h5>
+										<h5>@band.Band.Name</h5>
 										<span class="badge bg-info rounded-pill">
-											@band.Genre
+											@band.Band.Genre
 										</span>
 									</div>
 								</div>

--- a/ShowTime/Components/Pages/Festivals/FestivalDetails.razor.cs
+++ b/ShowTime/Components/Pages/Festivals/FestivalDetails.razor.cs
@@ -35,7 +35,8 @@ namespace ShowTime.Components.Pages.Festivals
 
             try
             {
-                Festival = await FestivalService.GetByIdIncludingAsync(FestivalId, f => f.Bands);
+                Festival = await FestivalService.GetByIdIncludingAsync(FestivalId, f => f.BandFestivals,
+                                                                                   f => (f.BandFestivals as BandFestival).Band);
                 
                 if (Festival == null)
                 {

--- a/ShowTime/Components/Pages/Festivals/FestivalList.razor
+++ b/ShowTime/Components/Pages/Festivals/FestivalList.razor
@@ -88,7 +88,7 @@
                                 <Div Margin="Margin.Is2.FromBottom">
                                     <Icon Name="IconName.Users" Margin="Margin.Is1.FromEnd" />
                                     <span class="text-muted">
-                                        Bands: @(festival.Bands?.Count ?? 0)
+                                        Bands: @(festival.BandFestivals?.Count ?? 0)
                                     </span>
                                 </Div>
                                 <Div>

--- a/ShowTime/Components/Pages/Festivals/FestivalList.razor.cs
+++ b/ShowTime/Components/Pages/Festivals/FestivalList.razor.cs
@@ -15,13 +15,15 @@ namespace ShowTime.Components.Pages.Festivals
         {
             try
             {
-                Festivals = (await FestivalService.GetAllIncludingAsync(f => f.Bands,
+                Festivals = (await FestivalService.GetAllIncludingAsync(f => f.BandFestivals,
+                                                                        f => (f.BandFestivals as BandFestival).Band,
                                                                         f => f.Bookings)).ToList();
             }
             catch (Exception ex)
             {
                 Console.WriteLine($"Error loading festivals: {ex.Message}");
             }
+
         }
 
         private void NavigateToFestivalDetails(int festivalId)

--- a/ShowTime/Context/ShowTimeDbContext.cs
+++ b/ShowTime/Context/ShowTimeDbContext.cs
@@ -11,5 +11,22 @@ namespace ShowTime.Context
         public DbSet<Band> Bands { get; set; } = null!;
         public DbSet<Booking> Bookings { get; set; } = null!;
         public DbSet<Festival> Festivals { get; set; } = null!;
+        public DbSet<BandFestival> BandFestivals { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<BandFestival>()
+                .HasKey(bf => new { bf.BandsId, bf.FestivalsId });
+
+            modelBuilder.Entity<BandFestival>()
+                .HasOne(bf => bf.Band)
+                .WithMany(b => b.BandFestivals)
+                .HasForeignKey(bf => bf.BandsId);
+
+            modelBuilder.Entity<BandFestival>()
+                .HasOne(bf => bf.Festival)
+                .WithMany(f => f.BandFestivals)
+                .HasForeignKey(bf => bf.FestivalsId);
+        }
     }
 }

--- a/ShowTime/Entities/Band.cs
+++ b/ShowTime/Entities/Band.cs
@@ -7,7 +7,7 @@ namespace ShowTime.Entities
         public int Id { get; set; }
         public string Name { get; set; } = string.Empty;
         public Genre Genre { get; set; }
-        public ICollection<Festival> Festivals { get; set; } = [];
+        public ICollection<BandFestival> BandFestivals { get; set; } = [];
         public byte[]? Photo { get; set; }
     }
 }

--- a/ShowTime/Entities/BandFestival.cs
+++ b/ShowTime/Entities/BandFestival.cs
@@ -1,0 +1,11 @@
+﻿namespace ShowTime.Entities
+{
+    public class BandFestival
+    {
+        public int BandsId { get; set; }
+        public int FestivalsId { get; set; }
+        public Band? Band { get; set; }
+        public Festival? Festival { get; set; }
+        public int BandOrder { get; set; }
+    }
+}

--- a/ShowTime/Entities/Festival.cs
+++ b/ShowTime/Entities/Festival.cs
@@ -8,7 +8,7 @@
         public DateTime StartDate { get; set; }
         public DateTime EndDate { get; set; }
         public byte[]? Photo { get; set; }
-        public ICollection<Band> Bands { get; set; } = [];
+        public ICollection<BandFestival> BandFestivals { get; set; } = [];
         public ICollection<Booking> Bookings { get; set; } = [];
     }
 }

--- a/ShowTime/Migrations/20250704082753_AddBandFestival.Designer.cs
+++ b/ShowTime/Migrations/20250704082753_AddBandFestival.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ShowTime.Context;
 
@@ -11,9 +12,11 @@ using ShowTime.Context;
 namespace ShowTime.Migrations
 {
     [DbContext(typeof(ShowTimeDbContext))]
-    partial class ShowTimeDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250704082753_AddBandFestival")]
+    partial class AddBandFestival
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ShowTime/Migrations/20250704082753_AddBandFestival.cs
+++ b/ShowTime/Migrations/20250704082753_AddBandFestival.cs
@@ -1,0 +1,83 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ShowTime.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBandFestival : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "BandFestival");
+
+            migrationBuilder.CreateTable(
+                name: "BandFestivals",
+                columns: table => new
+                {
+                    BandsId = table.Column<int>(type: "int", nullable: false),
+                    FestivalsId = table.Column<int>(type: "int", nullable: false),
+                    BandOrder = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_BandFestivals", x => new { x.BandsId, x.FestivalsId });
+                    table.ForeignKey(
+                        name: "FK_BandFestivals_Bands_BandsId",
+                        column: x => x.BandsId,
+                        principalTable: "Bands",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_BandFestivals_Festivals_FestivalsId",
+                        column: x => x.FestivalsId,
+                        principalTable: "Festivals",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BandFestivals_FestivalsId",
+                table: "BandFestivals",
+                column: "FestivalsId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "BandFestivals");
+
+            migrationBuilder.CreateTable(
+                name: "BandFestival",
+                columns: table => new
+                {
+                    BandsId = table.Column<int>(type: "int", nullable: false),
+                    FestivalsId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_BandFestival", x => new { x.BandsId, x.FestivalsId });
+                    table.ForeignKey(
+                        name: "FK_BandFestival_Bands_BandsId",
+                        column: x => x.BandsId,
+                        principalTable: "Bands",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_BandFestival_Festivals_FestivalsId",
+                        column: x => x.FestivalsId,
+                        principalTable: "Festivals",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BandFestival_FestivalsId",
+                table: "BandFestival",
+                column: "FestivalsId");
+        }
+    }
+}

--- a/ShowTime/Services/Implementations/FestivalService.cs
+++ b/ShowTime/Services/Implementations/FestivalService.cs
@@ -11,15 +11,15 @@ namespace ShowTime.Services.Implementations
             var festival = await festivalRepository.GetByIdAsync(festivalId)
                 ?? throw new ArgumentException($"Festival with ID {festivalId} not found.");
 
-            var band = await bandRepository.GetByIdAsync(bandId)
-                ?? throw new ArgumentException($"Band with ID {bandId} not found.");
-
-            if (festival.Bands.Any(b => b.Id == bandId))
+            if (festival.BandFestivals.Any(b => b.BandsId == bandId))
             {
                 throw new InvalidOperationException($"Band with ID {bandId} is already added to the festival with ID {festivalId}.");
             }
+            var band = await bandRepository.GetByIdAsync(bandId)
+                ?? throw new ArgumentException($"Band with ID {bandId} not found.");
 
-            festival.Bands.Add(band);
+            festival.BandFestivals.Add(new BandFestival { FestivalsId = festivalId, BandsId = bandId } );
+
             await festivalRepository.UpdateAsync(festival);
             await festivalRepository.SaveChangesAsync();
         }


### PR DESCRIPTION
Refactor Band-Festival relationship with BandFestival entity

Refactored the many-to-many relationship between `Band` and `Festival` by introducing the `BandFestival` entity. This intermediary entity enables storing additional properties like `BandOrder`. Updated database schema, EF Core model, service layer, backend logic, and UI components to reflect the new structure. Improved flexibility and maintainability of the relationship.