### PR TITLE
Add editing support for bands and festivals

### DIFF
--- a/ShowTime/Components/Pages/Bands/CreateBand.razor
+++ b/ShowTime/Components/Pages/Bands/CreateBand.razor
@@ -1,12 +1,17 @@
-﻿@page "/CreateBand"
+﻿@page "/CreateBand/{BandIdQueryParameter:int?}"
+
 @rendermode InteractiveServer
+
 @inject IBandService BandService
 @inject NavigationManager NavigationManager
+@inject IJSRuntime JS
 
 <Div Class="d-flex justify-content-between align-items-center mb-4">
 	<Heading Size="HeadingSize.Is2" TextColor="TextColor.Primary" TextWeight="TextWeight.Bold">
-		<Icon Name="IconName.Add" Margin="Margin.Is2.FromEnd" />
-		Create New Band
+		<Icon Name="@(BandIdQueryParameter == null ? IconName.Add : IconName.Save)" Margin="Margin.Is2.FromEnd" />
+		@(BandIdQueryParameter == null
+				? "Create New Band"
+				: $"Edit {BandToUpdate?.Name ?? ""} Band")
 	</Heading>
 </Div>
 
@@ -79,10 +84,12 @@
 
 					<Button Color="Color.Primary"
 							Size="Size.Large"
-							@onclick="AddBand"
+							@onclick="@(BandIdQueryParameter == null ? AddBand : UpdateBand)"
 							Style="min-width: 120px;">
 						<Icon Name="IconName.Save" Margin="Margin.Is1.FromEnd" />
-						Create Band
+						@(BandIdQueryParameter == null
+						? "Create Band"
+						: $"Update {BandToUpdate?.Name}")
 					</Button>
 				</Div>
 			</Form>

--- a/ShowTime/Components/Pages/Bands/CreateBand.razor.cs
+++ b/ShowTime/Components/Pages/Bands/CreateBand.razor.cs
@@ -1,5 +1,6 @@
 using Blazorise;
 using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
 using ShowTime.Entities;
 using ShowTime.Enum;
 
@@ -7,10 +8,31 @@ namespace ShowTime.Components.Pages.Bands
 {
     public partial class CreateBand
     {
+        [Parameter]
+        public int? BandIdQueryParameter { get; set; } = -1;
+
+        private Band? BandToUpdate { get; set; } = null;
+
         private string NewBandName = string.Empty;
         private Genre NewBandGenre;
         private byte[]? NewBandPhoto;
 
+        private string errorMessage = string.Empty;
+
+
+        protected override async Task OnInitializedAsync()
+        {
+            await FillFields();
+        }
+
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            await base.OnAfterRenderAsync(firstRender);
+            if (firstRender)
+            {
+                await JS.InvokeVoidAsync("scrollToTop");
+            }
+        }
 
         private async Task AddBand()
         {
@@ -28,6 +50,57 @@ namespace ShowTime.Components.Pages.Bands
             NewBandPhoto = null;
 
             NavigationManager.NavigateTo("/BandList");
+        }
+
+        private async Task UpdateBand()
+        {
+            if (BandToUpdate == null)
+            {
+                errorMessage = "Band to update is not set.";
+                return;
+            }
+
+            BandToUpdate.Name = NewBandName;
+            BandToUpdate.Genre = NewBandGenre;
+            BandToUpdate.Photo = NewBandPhoto;
+
+            await BandService.UpdateAsync(BandToUpdate);
+
+            NewBandName = string.Empty;
+            NewBandGenre = Genre.Rock;
+            NewBandPhoto = null;
+
+            NavigateToBandList();
+        }
+
+        private async Task FillFields()
+        {
+            if (BandIdQueryParameter != null)
+            {
+                int BandId = BandIdQueryParameter.Value;
+                errorMessage = string.Empty;
+                try
+                {
+                    BandToUpdate = await BandService.GetByIdAsync(BandId);
+
+                    if (BandToUpdate == null)
+                    {
+                        errorMessage = "Band not found.";
+                    }
+                    else
+                    {
+                        NewBandName = BandToUpdate.Name;
+                        NewBandGenre = BandToUpdate.Genre;
+                        NewBandPhoto = BandToUpdate.Photo;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    errorMessage = $"Error loading band details: {ex.Message}";
+                    Console.WriteLine($"Error loading band with id {BandId} - {ex.Message}");
+                }
+            }
+
         }
 
         private async Task OnFileUpload(FileUploadEventArgs e)

--- a/ShowTime/Components/Pages/Festivals/CreateFestival.razor
+++ b/ShowTime/Components/Pages/Festivals/CreateFestival.razor
@@ -12,7 +12,7 @@
         <Icon Name="@(FestivalIdQueryParameter == null ? IconName.Add : IconName.Save)" Margin="Margin.Is2.FromEnd" />
         @(FestivalIdQueryParameter == null
             ? "Create New Festival"
-            : $"Update {FestivalToUpdate?.Name ?? "Festival"} Festival")
+            : $"Edit {FestivalToUpdate?.Name ?? ""} Festival")
     </Heading>
 </Div>
 
@@ -144,7 +144,7 @@
                         <Icon Name="IconName.Save" Margin="Margin.Is1.FromEnd" />
                         @(FestivalIdQueryParameter == null
                             ? "Create Festival"
-                            : $"Update")
+                            : $"Update {FestivalToUpdate?.Name}")
                     </Button>
                 </Div>
             </Form>

--- a/ShowTime/Components/Pages/Festivals/CreateFestival.razor.cs
+++ b/ShowTime/Components/Pages/Festivals/CreateFestival.razor.cs
@@ -95,6 +95,14 @@ namespace ShowTime.Components.Pages.Festivals
             FestivalToUpdate.Photo = NewFestivalPhoto;
 
             await FestivalService.UpdateAsync(FestivalToUpdate);
+
+            NewFestivalName = string.Empty;
+            NewFestivalLocation = string.Empty;
+            NewFestivalStartDate = DateTime.Now;
+            NewFestivalEndDate = DateTime.Now.AddDays(1);
+            SelectedBandIds.Clear();
+            NewFestivalPhoto = null;
+
             NavigateToFestivalList();
         }
 


### PR DESCRIPTION
Add editing support for bands and festivals

Enhanced `CreateBand.razor` and `CreateFestival.razor` to support editing existing entities. Updated routes, UI, and button functionality to dynamically adjust for creation or editing. Added logic for populating form fields, error handling, and navigation after updates. Improved user experience with scroll-to-top behavior on render.